### PR TITLE
Feat/socket backlog metric

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -558,7 +558,7 @@ class Arbiter(object):
                                   "value": active_worker_count,
                                   "mtype": "gauge"})
 
-       backlog = sum([sock.get_backlog() for sock in self.LISTENERS])
+        backlog = sum([sock.get_backlog() for sock in self.LISTENERS])
         if backlog:
             self.log.debug("socket backlog: {0}".format(backlog),
                            extra={"metric": "gunicorn.backlog",

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -558,6 +558,13 @@ class Arbiter(object):
                                   "value": active_worker_count,
                                   "mtype": "gauge"})
 
+       backlog = sum([sock.get_backlog() for sock in self.LISTENERS])
+        if backlog:
+            self.log.debug("socket backlog: {0}".format(backlog),
+                           extra={"metric": "gunicorn.backlog",
+                                  "value": backlog,
+                                  "mtype": "histogram"})
+
     def spawn_worker(self):
         self.worker_age += 1
         worker = self.worker_class(self.worker_age, self.pid, self.LISTENERS,

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -70,6 +70,9 @@ class BaseSocket(object):
 
         self.sock = None
 
+    def get_backlog(self):
+        return 0
+
 
 class TCPSocket(BaseSocket):
 
@@ -88,6 +91,18 @@ class TCPSocket(BaseSocket):
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         return super().set_options(sock, bound=bound)
 
+    def get_backlog(self):
+        if self.sock and PLATFORM == "linux":
+            # tcp_info struct from include/uapi/linux/tcp.h
+            fmt = 'B'*8+'I'*24
+            try:
+                tcp_info_struct = self.sock.getsockopt(socket.IPPROTO_TCP,
+                                                      socket.TCP_INFO, 104)
+                # 12 is tcpi_unacked
+                return struct.unpack(fmt, tcp_info_struct)[12]
+            except AttributeError:
+                pass
+        return 0
 
 class TCP6Socket(TCPSocket):
 

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -11,7 +11,7 @@ import sys
 import time
 
 from gunicorn import util
-
+PLATFORM = sys.platform
 
 class BaseSocket(object):
 


### PR DESCRIPTION
Porting [the socket backlog metric implementation](https://github.com/raags/gunicorn/commit/11d929f6386f3207f8c88f418fb5c2599dfae896) to the latest Gunicorn.

This change will give visibility on concurrency and worker saturation. I tried to implement it with monkey patch but got very messy. 

![image](https://user-images.githubusercontent.com/33836178/149387849-4423053c-0b79-4839-a737-4bec80e631cd.png)

In case you want to see this in action:

```bash
python3 setup.py install
```

```docker
docker run -d --name graphite --restart=always -p 80:80 -p 2003-2004:2003-2004 -p 2023-2024:2023-2024 -p 8125:8125/udp -p 8126:8126 graphiteapp/graphite-statsd
```

```python
# myapp.py
def app(environ, start_response):
    data = b"Hello, World!\n"
    start_response("200 OK", [
        ("Content-Type", "text/plain"),
        ("Content-Length", str(len(data)))
    ])
    return iter([data])
```

```bash
gunicorn -w 4 myapp:app --statsd-host=localhost:8125 --statsd-prefix=helloworld --bind 127.0.0.1:8080
```

```bash
open http://127.0.0.1
```

```bash
for i in `seq 500`; do curl http://127.0.0.1:8080 && sleep $((RANDOM % 5)); done
```


